### PR TITLE
refactor: externalize firebase API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.log
+.DS_Store
+public/firebase-config.js
+node_modules/

--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ PORT=<optional port, defaults to 3000>
 ```
 
 Do not commit the `.env` file to version control.
+
+## Firebase configuration
+
+Create `public/firebase-config.js` by copying `public/firebase-config.example.js` and filling in your Firebase project details. This file is ignored by Git so your API key remains private.

--- a/public/firebase-config.example.js
+++ b/public/firebase-config.example.js
@@ -1,0 +1,8 @@
+window.firebaseConfig = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'spatial-cognition-study-8c068.firebaseapp.com',
+  projectId: 'spatial-cognition-study-8c068',
+  storageBucket: 'spatial-cognition-study-8c068.appspot.com',
+  messagingSenderId: '794653517672',
+  appId: '1:794653517672:web:7a6cea1b86581b979118dd'
+};

--- a/public/index.html
+++ b/public/index.html
@@ -811,18 +811,10 @@
   <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-storage-compat.js"></script>
 
   <!-- Firebase Initialization -->
+  <script src="firebase-config.js"></script>
   <script>
     // Important: storageBucket should be appspot.com, not firebasestorage.app
-    const firebaseConfig = {
-      apiKey: "AIzaSyCIwCPIWoCvIUFuq0yyZGvuE9cqEX_d6Js",
-      authDomain: "spatial-cognition-study-8c068.firebaseapp.com",
-      projectId: "spatial-cognition-study-8c068",
-      storageBucket: "spatial-cognition-study-8c068.appspot.com",
-      messagingSenderId: "794653517672",
-      appId: "1:794653517672:web:7a6cea1b86581b979118dd"
-    };
-
-    firebase.initializeApp(firebaseConfig);
+    firebase.initializeApp(window.firebaseConfig);
     window.db = firebase.firestore();
     window.storage = firebase.storage();
     console.log("Firebase initialized");


### PR DESCRIPTION
## Summary
- load Firebase config from external file and remove hard-coded API key
- add `.gitignore` and example Firebase config file
- document Firebase config setup in README

## Testing
- `npm run lint` *(fails: No files matching the pattern "src/**/*.js" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b35395c3a48326ae94482ee9b84f4b