### PR TITLE
Clarify optional EEG scheduling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -500,6 +500,10 @@
         <h3>Questions</h3>
         <p><a href="mailto:action.brain.lab@gallaudet.edu">action.brain.lab@gallaudet.edu</a></p>
 
+        <div class="info-box important" style="margin-top: 24px;">
+          <strong>No EEG appointment?</strong> That's okay — you can skip scheduling and jump straight to the online tasks by clicking <em>Skip EEG &amp; Continue to Online Tasks</em> at the bottom of this page.
+        </div>
+
         <div class="card" style="margin-top: 32px; border: 2px solid var(--info); background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%);">
           <div style="text-align: center;">
             <div style="font-size: 48px; margin-bottom: 16px;">🧠</div>
@@ -545,14 +549,14 @@
               </button>
             </div>
 
-            <p style="margin-top: 12px; font-size: 14px; color: var(--text-secondary);">
-              Not in the DC area? No problem! You can still participate in the online portion.
-            </p>
+              <div class="info-box important" style="margin-top: 20px;">
+                <strong>EEG scheduling is optional.</strong> Not in the DC area or prefer to skip? Just choose <em>Skip EEG &amp; Continue to Online Tasks</em> below.
+              </div>
           </div>
         </div>
 
         <div class="button-group" style="margin-top: 20px;">
-          <button class="button primary" onclick="proceedToTasks()">Continue</button>
+          <button class="button primary" onclick="proceedToTasks()">Skip EEG &amp; Continue to Online Tasks</button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Emphasize that EEG scheduling is optional with a prominent notice
- Rename continue button to "Skip EEG & Continue to Online Tasks"

## Testing
- `npm run lint` *(fails: No files matching pattern "src/**/*.js" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38c3fb06c8326a93d7f64d3193b1c